### PR TITLE
fix: add wildcard mappings for dist and esm directories in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
       "import": "./dist/esm/merge-styles.js",
       "require": "./dist/merge-styles.js",
       "default": "./dist/umd/merge-styles.js"
-    }
+    },
+    "./dist/*": "./dist/*",
+    "./dist/esm/*": "./dist/esm/*"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
# Pull Request

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## Description

Except core import, other imports don't work as expected in Expo with metro bundler